### PR TITLE
fix misleading note

### DIFF
--- a/pages/docs/create.md
+++ b/pages/docs/create.md
@@ -37,7 +37,7 @@ db.Create(&animal)
 // animal.Name => 'galeone'
 ```
 
-**NOTE** all fields having a zero value, like `0`, `''`, `false` or other [zero values](https://tour.golang.org/basics/12), won't be saved into the database but will use its default value. If you want to avoid this, consider using a pointer type or scanner/valuer, e.g:
+**NOTE** all fields having a zero value, like `0`, `''`, `false` or other [zero values](https://tour.golang.org/basics/12), will be saved into the database. If you want to avoid this, consider using a pointer type or scanner/valuer, e.g:
 
 ```go
 // Use pointer value


### PR DESCRIPTION
the behavior described in the note is different than I tested.

``` go
var an Animal
an.Age = 50
db.Create(&an)

var u Animal
db.Last(&u)
u.Age = 0
db.Save(&u)
```

the code above will update `age = 0` to the database